### PR TITLE
Fix bugs & errors with metric form.

### DIFF
--- a/src/components/MetricsForm.tsx
+++ b/src/components/MetricsForm.tsx
@@ -1,46 +1,124 @@
-"use client"
+"use client";
 
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import { Form, FormField, FormItem, FormLabel, FormControl } from "@/components/ui/form"
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-import { RefreshCw } from 'lucide-react'
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Form, FormField, FormItem, FormLabel, FormControl } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { RefreshCw } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
 
 const formSchema = z.object({
   url: z.string().url("Please enter a valid URL."),
-})
+});
+
+const errorTitles = [
+  "Oops! We hit a snag:",
+  "Houston, we have a problem:",
+  "Well, this is awkward:",
+  "Unexpected detour:",
+  "That didn't go as planned:",
+  "Minor setback detected:",
+  "Plot twist:",
+  "Hmm, something's not right:",
+  "We ran into a hiccup:",
+  "Quick heads up:",
+];
 
 interface MetricsFormProps {
-  onSubmit: (url: string) => void
-  isLoading: boolean
-  autoRefresh: boolean
-  onAutoRefreshToggle: () => void
-  currentUrl?: string
+  onSubmit: (url: string) => void;
+  isLoading: boolean;
+  autoRefresh: boolean;
+  onAutoRefreshToggle: () => void;
+  currentUrl?: string;
 }
 
-export function MetricsForm({ 
-  onSubmit, 
-  isLoading, 
-  autoRefresh, 
-  onAutoRefreshToggle,
-  currentUrl 
-}: MetricsFormProps) {
+export function MetricsForm({ onSubmit, isLoading, autoRefresh, onAutoRefreshToggle, currentUrl }: MetricsFormProps) {
+  const { toast } = useToast();
+  const [localLoading, setLocalLoading] = useState(false); // 🔥 Instant UI update
+
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      url: currentUrl || ""
+      url: currentUrl || "",
+    },
+  });
+
+  const getRandomErrorTitle = () => {
+    const randomIndex = Math.floor(Math.random() * errorTitles.length);
+    return errorTitles[randomIndex];
+  };
+
+  const checkUrlAvailability = async (url: string): Promise<boolean> => {
+    const headers = {
+      Accept: "text/plain",
+      "User-Agent": "Mozilla/5.0 (compatible; MetricsFetcher/1.0)",
+    };
+
+    try {
+      let response: Response | null = null;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15000); // ⏳ 15-second timeout
+
+      try {
+        response = await fetch(url, { method: "HEAD", headers, signal: controller.signal });
+      } catch (err) {
+        console.warn(`HEAD request failed, falling back to GET for: ${url}`);
+      }
+
+      if (!response || !response.ok) {
+        response = await fetch(url, { method: "GET", headers, signal: controller.signal });
+
+        if (!response.ok) {
+          throw new Error(`Failed to fetch "${url}" (Status: ${response.status})`);
+        }
+      }
+
+      clearTimeout(timeoutId);
+
+      const contentType = response.headers.get("content-type");
+      if (!contentType?.includes("text/plain")) {
+        throw new Error(`Invalid metrics endpoint: "${url}" does not return text/plain content`);
+      }
+
+      return true;
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.name === "AbortError") {
+          toast({
+            variant: "destructive",
+            title: getRandomErrorTitle(),
+            description: `Connection timed out while trying to reach "${url}". The server might be slow or unreachable.`,
+          });
+        } else {
+          toast({
+            variant: "destructive",
+            title: getRandomErrorTitle(),
+            description: error.message,
+          });
+        }
+      }
+      return false;
     }
-  })
+  };
+
+  const handleSubmit = async (data: z.infer<typeof formSchema>) => {
+    setLocalLoading(true); // 🔥 Instantly show loading state
+
+    const isAvailable = await checkUrlAvailability(data.url);
+    if (isAvailable) {
+      onSubmit(data.url);
+    }
+
+    setLocalLoading(false); // 🔥 Reset loading state after request
+  };
 
   return (
     <div className="flex items-center justify-center p-4">
       <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit((data) => onSubmit(data.url))}
-          className="flex flex-col gap-6 w-full max-w-md"
-        >
+        <form onSubmit={form.handleSubmit(handleSubmit)} className="flex flex-col gap-6 w-full max-w-md">
           <FormField
             control={form.control}
             name="url"
@@ -54,18 +132,15 @@ export function MetricsForm({
             )}
           />
           <div className="grid grid-cols-2 gap-4">
-            <Button 
-              type="submit" 
-              disabled={isLoading} 
-              className="rounded-xl hover:bg-[#4A89F3]"
-            >
-              Fetch Metrics
+            <Button type="submit" disabled={isLoading || localLoading} className="rounded-xl hover:bg-[#4A89F3]">
+              {localLoading ? "Fetching..." : "Fetch Metrics"} {/* 🔥 Instant text change */}
             </Button>
             <Button
               type="button"
               variant={autoRefresh ? "secondary" : "outline"}
               onClick={onAutoRefreshToggle}
               className="gap-2 rounded-xl"
+              disabled={isLoading}
             >
               <RefreshCw className={`h-4 w-4 ${autoRefresh ? "animate-spin" : ""}`} />
               Auto-refresh
@@ -74,5 +149,5 @@ export function MetricsForm({
         </form>
       </Form>
     </div>
-  )
+  );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -290,6 +290,7 @@ export default function Dashboard() {
         .map((m) => m.labels?.hostname)
     ).size;
 
+
     return {
       totalWatchRequests,
       uniqueHosts,


### PR DESCRIPTION
In this PR, I've gone ahead and done, aswell as updated the following:

When entering anything into the metrics url input, it'd try to fetch the data which wasn't accounted for. Thus, I've gone ahead and added a safety check to fetch the url first and foremost before receiving any data. It'll check the requested url 3-4 times then process the data. For example, if https://server.vidbinge.com/metrics is down, it'll return with an error. On the other hand, if https://server.fifthwit.tech/metrics is live and running as expected; it'll disable the button -> see if the urls online via some requests -> fetch data -> parse the data -> display. This is ensuring smooth flowing throughout the fetching function. Furthermore, I've randomized the list of placeholders using ChatGPT to ensure the error messages are funny and still contain valuable information used for developers to debug.
![image](https://github.com/user-attachments/assets/ef08613e-8b2c-4737-a080-957076c9d6f2)
